### PR TITLE
[프레디, 노을] 1단계 준비 과정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,8 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.2.3'
     implementation 'org.apache.commons:commons-dbcp2:2.5.0'
     implementation 'org.reflections:reflections:0.9.11'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'
     testImplementation 'org.assertj:assertj-core:3.11.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     runtimeOnly 'com.h2database:h2:1.4.200'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,11 @@ dependencies {
     implementation 'org.apache.commons:commons-dbcp2:2.5.0'
     implementation 'org.reflections:reflections:0.9.11'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     runtimeOnly 'com.h2database:h2:1.4.200'
+
 }
 
 test {

--- a/src/main/java/util/HttpRequestUtils.java
+++ b/src/main/java/util/HttpRequestUtils.java
@@ -1,11 +1,12 @@
 package util;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class HttpRequestUtils {
     /**
@@ -51,6 +52,11 @@ public class HttpRequestUtils {
 
     public static Pair parseHeader(String header) {
         return getKeyValue(header, ": ");
+    }
+
+    public static List<String> parseStatusLine(String statusLine) {
+        return Arrays.stream(statusLine.split(" "))
+                .collect(Collectors.toList());
     }
 
     public static class Pair {

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -13,7 +13,7 @@ public class Body {
         this.data = data;
     }
 
-    public static Body create(String bodyText) {
+    public static Body from(String bodyText) {
         return new Body(bodyText.getBytes(DEFAULT_ENCODING));
     }
 

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -2,6 +2,7 @@ package webserver;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 public class Body {
     private static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
@@ -14,5 +15,18 @@ public class Body {
 
     public static Body create(String bodyText) {
         return new Body(bodyText.getBytes(DEFAULT_ENCODING));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Body body = (Body) o;
+        return Arrays.equals(data, body.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(data);
     }
 }

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -29,4 +29,11 @@ public class Body {
     public int hashCode() {
         return Arrays.hashCode(data);
     }
+
+    @Override
+    public String toString() {
+        return "Body{" +
+                "data=" + new String(data) +
+                '}';
+    }
 }

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -17,6 +17,10 @@ public class Body {
         return new Body(bodyText.getBytes(DEFAULT_ENCODING));
     }
 
+    public String asString() {
+        return new String(data, DEFAULT_ENCODING);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -1,0 +1,18 @@
+package webserver;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class Body {
+    private static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
+
+    private byte[] data;
+
+    private Body(byte[] data) {
+        this.data = data;
+    }
+
+    public static Body create(String bodyText) {
+        return new Body(bodyText.getBytes(DEFAULT_ENCODING));
+    }
+}

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -17,8 +17,12 @@ public class Body {
         return new Body(bodyText.getBytes(DEFAULT_ENCODING));
     }
 
-    public String asString() {
+    public String getString() {
         return new String(data, DEFAULT_ENCODING);
+    }
+
+    public byte[] getBytes() {
+        return data;
     }
 
     @Override

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,21 +1,21 @@
 package webserver;
 
 public class GetMessage {
-    private Header header;
+    private RequestHeader header;
 
-    private GetMessage(Header header) {
+    private GetMessage(RequestHeader header) {
         this.header = header;
     }
 
     public static GetMessage from(String getMessage) {
-        return new GetMessage(Header.of(getMessage, "request"));
+        return new GetMessage(Header.requestHeaderFrom(getMessage));
     }
 
-    public Header getHeader() {
+    public RequestHeader getHeader() {
         return header;
     }
 
     public String getMethod() {
-        return ((RequestHeader) header).getMethod();
+        return header.getMethod();
     }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -14,4 +14,8 @@ public class GetMessage {
     public Header getHeader() {
         return header;
     }
+
+    public String getMethod() {
+        return ((RequestHeader) header).getMethod();
+    }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -5,6 +5,7 @@ import util.HttpRequestUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Objects;
 
 public class GetMessage implements RequestMessage {
     private RequestHeader header;
@@ -38,5 +39,18 @@ public class GetMessage implements RequestMessage {
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + statusLine.get(RequestHeader.PATH_KEY), e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GetMessage that = (GetMessage) o;
+        return Objects.equals(header, that.header);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(header);
     }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,6 +1,6 @@
 package webserver;
 
-public class GetMessage {
+public class GetMessage implements RequestMessage {
     private RequestHeader header;
 
     private GetMessage(RequestHeader header) {
@@ -11,10 +11,12 @@ public class GetMessage {
         return new GetMessage(Header.requestHeaderFrom(getMessage));
     }
 
+    @Override
     public RequestHeader getHeader() {
         return header;
     }
 
+    @Override
     public String getMethod() {
         return header.getMethod();
     }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,5 +1,11 @@
 package webserver;
 
+import util.HttpRequestUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
 public class GetMessage implements RequestMessage {
     private RequestHeader header;
 
@@ -19,5 +25,17 @@ public class GetMessage implements RequestMessage {
     @Override
     public String getMethod() {
         return header.getMethod();
+    }
+
+    public Map<String, String> getParameters() {
+        Map<String, String> statusLine = header.getStatusLineAttributes();
+
+        try {
+            URI uri = new URI(statusLine.get(RequestHeader.PATH_KEY));
+            return HttpRequestUtils.parseQueryString(uri.getQuery());
+            
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + statusLine.get(RequestHeader.PATH_KEY), e);
+        }
     }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,0 +1,17 @@
+package webserver;
+
+public class GetMessage {
+    private Header header;
+
+    private GetMessage(Header header) {
+        this.header = header;
+    }
+
+    public static GetMessage from(String getMessage) {
+        return new GetMessage(Header.of(getMessage, "request"));
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+}

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -27,13 +27,14 @@ public class GetMessage implements RequestMessage {
         return header.getMethod();
     }
 
+    @Override
     public Map<String, String> getParameters() {
         Map<String, String> statusLine = header.getStatusLineAttributes();
 
         try {
             URI uri = new URI(statusLine.get(RequestHeader.PATH_KEY));
             return HttpRequestUtils.parseQueryString(uri.getQuery());
-            
+
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + statusLine.get(RequestHeader.PATH_KEY), e);
         }

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -25,24 +25,14 @@ public abstract class Header {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
         List<String> statusLine = HttpRequestUtils.parseStatusLine(splittedHeaderTexts[0]);
 
-        Map<String, String> statusLineAttributes = new HashMap<>();
-        statusLineAttributes.put(RequestHeader.METHOD_KEY, statusLine.get(0));
-        statusLineAttributes.put(RequestHeader.PATH_KEY, statusLine.get(1));
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(2));
-
-        return new RequestHeader(statusLineAttributes, attributeFrom(headerText));
+        return RequestHeader.of(statusLine, attributeFrom(headerText));
     }
 
     public static ResponseHeader responseHeaderFrom(String headerText) {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
         List<String> statusLine = HttpRequestUtils.parseStatusLine(splittedHeaderTexts[0]);
 
-        Map<String, String> statusLineAttributes = new HashMap<>();
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(0));
-        statusLineAttributes.put(ResponseHeader.STATUS_CODE_KEY, statusLine.get(1));
-        statusLineAttributes.put(ResponseHeader.STATUS_TEXT_KEY, statusLine.get(2));
-
-        return new ResponseHeader(statusLineAttributes, attributeFrom(headerText));
+        return ResponseHeader.of(statusLine, attributeFrom(headerText));
     }
 
     private static Map<String, String> attributeFrom(String headerText) {

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 public class Header {
-
     private String protocolVersion;
     private String statusCode;
     private String statusText;
@@ -25,32 +24,71 @@ public class Header {
     public static Header from(String headerText) {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
 
+        Builder builder = new Builder();
         List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
 
-        String protocolVersion = "";
-        String statusCode = "";
-        String statusText = "";
-        String contentType = "";
-        int contentLength = -1;
 
         for (String splittedHeaderText : splittedHeaderTexts) {
             pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
 
             HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
 
-            if (pair != null) {
-                contentType = pair.getKey().equals("Content-Type") ? pair.getValue() : contentType;
-                contentLength = pair.getKey().equals("Content-Length") ? Integer.parseInt(pair.getValue()) : contentLength;
+            if (pair != null && pair.getKey().equals("Content-Type")) {
+                builder.contentType(pair.getValue());
+            }
+            if (pair != null && pair.getKey().equals("Content-Length")) {
+                builder.contentLength(Integer.parseInt(pair.getValue()));
             }
         }
 
         String[] statusLine = splittedHeaderTexts[0].split(" ");
 
-        protocolVersion = statusLine[0];
-        statusCode = statusLine[1];
-        statusText = statusLine[2];
+        builder.protocolVersion(statusLine[0]);
+        builder.statusCode(statusLine[1]);
+        builder.statusText(statusLine[2]);
 
-        return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String protocolVersion;
+        private String statusCode;
+        private String statusText;
+        private String contentType;
+        private int contentLength;
+
+        public Builder protocolVersion(String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder statusCode(String statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder statusText(String statusText) {
+            this.statusText = statusText;
+            return this;
+        }
+
+        public Builder contentType(String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public Builder contentLength(int contentLength) {
+            this.contentLength = contentLength;
+            return this;
+        }
+
+        public Header build() {
+            return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
+        }
     }
 
     @Override

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -1,28 +1,84 @@
 package webserver;
 
-import java.util.Objects;
+import util.HttpRequestUtils;
 
-public class Header {
-    private String protocolVersion;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-    public Header(String protocolVersion) {
-        this.protocolVersion = protocolVersion;
+public abstract class Header {
+    protected static final String PROTOCOL_VERSION_KEY = "protocolVersion";
+
+    protected Map<String, String> statusLineAttributes;
+    private Map<String, String> attributes;
+
+    public Header(Map<String, String> attributes) {
+        this.attributes = attributes;
+        this.statusLineAttributes = new HashMap<>();
     }
 
-    public String getProtocolVersion() {
-        return protocolVersion;
+    public static Header of(String headerText, String type) {
+        Map<String, String> attributes = attributeFrom(headerText);
+
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        Header header = of(attributes, type);
+        header.putStatusLine(statusLine);
+
+        return header;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Header header = (Header) o;
-        return Objects.equals(protocolVersion, header.protocolVersion);
+    private static Header of(Map<String, String> attributes, String type) {
+        switch (type) {
+            case "request":
+                return new RequestHeader(attributes);
+            case "response":
+                return new ResponseHeader(attributes);
+            default:
+                throw new IllegalStateException("Unexpected value: " + type);
+        }
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(protocolVersion);
+    private static Map<String, String> attributeFrom(String headerText) {
+        Map<String, String> attributes = new LinkedHashMap<>();
+
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null) {
+                attributes.put(pair.getKey(), pair.getValue());
+            }
+        }
+
+        return attributes;
     }
+
+    protected abstract void putStatusLine(String[] statusLine);
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public Map<String, String> getStatusLineAttributes() {
+        return statusLineAttributes;
+    }
+
+    public byte[] toByte() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(statusLine()).append(System.lineSeparator());
+
+        for (Map.Entry<String, String> entry : getAttributes().entrySet()) {
+            sb.append(entry.getKey() + ": " + entry.getValue() + System.lineSeparator());
+        }
+
+        sb.append(System.lineSeparator());
+
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    protected abstract String statusLine();
 }

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -9,6 +9,10 @@ public class Header {
         this.protocolVersion = protocolVersion;
     }
 
+    public String getProtocolVersion() {
+        return protocolVersion;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class Header {
     protected static final String PROTOCOL_VERSION_KEY = "protocolVersion";
@@ -81,4 +82,17 @@ public abstract class Header {
     }
 
     protected abstract String statusLine();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Header header = (Header) o;
+        return Objects.equals(statusLineAttributes, header.statusLineAttributes) && Objects.equals(attributes, header.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(statusLineAttributes, attributes);
+    }
 }

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -1,0 +1,68 @@
+package webserver;
+
+import util.HttpRequestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Header {
+
+    private String protocolVersion;
+    private String statusCode;
+    private String statusText;
+    private String contentType;
+    private int contentLength;
+
+    public Header(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
+        this.protocolVersion = protocolVersion;
+        this.statusCode = statusCode;
+        this.statusText = statusText;
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+    }
+
+    public static Header from(String headerText) {
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+
+        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
+
+        String protocolVersion = "";
+        String statusCode = "";
+        String statusText = "";
+        String contentType = "";
+        int contentLength = -1;
+
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
+
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null) {
+                contentType = pair.getKey().equals("Content-Type") ? pair.getValue() : contentType;
+                contentLength = pair.getKey().equals("Content-Length") ? Integer.parseInt(pair.getValue()) : contentLength;
+            }
+        }
+
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        protocolVersion = statusLine[0];
+        statusCode = statusLine[1];
+        statusText = statusLine[2];
+
+        return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Header header = (Header) o;
+        return contentLength == header.contentLength && Objects.equals(protocolVersion, header.protocolVersion) && Objects.equals(statusCode, header.statusCode) && Objects.equals(statusText, header.statusText) && Objects.equals(contentType, header.contentType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(protocolVersion, statusCode, statusText, contentType, contentLength);
+    }
+}

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -58,7 +58,7 @@ public abstract class Header {
         return statusLineAttributes;
     }
 
-    public byte[] toByte() {
+    public byte[] getBytes() {
         StringBuilder sb = new StringBuilder();
 
         sb.append(statusLine()).append(System.lineSeparator());

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -1,94 +1,12 @@
 package webserver;
 
-import util.HttpRequestUtils;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 public class Header {
     private String protocolVersion;
-    private String statusCode;
-    private String statusText;
-    private String contentType;
-    private int contentLength;
 
-    public Header(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
+    public Header(String protocolVersion) {
         this.protocolVersion = protocolVersion;
-        this.statusCode = statusCode;
-        this.statusText = statusText;
-        this.contentType = contentType;
-        this.contentLength = contentLength;
-    }
-
-    public static Header from(String headerText) {
-        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
-
-        Builder builder = new Builder();
-        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
-
-
-        for (String splittedHeaderText : splittedHeaderTexts) {
-            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
-
-            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
-
-            if (pair != null && pair.getKey().equals("Content-Type")) {
-                builder.contentType(pair.getValue());
-            }
-            if (pair != null && pair.getKey().equals("Content-Length")) {
-                builder.contentLength(Integer.parseInt(pair.getValue()));
-            }
-        }
-
-        String[] statusLine = splittedHeaderTexts[0].split(" ");
-
-        builder.protocolVersion(statusLine[0]);
-        builder.statusCode(statusLine[1]);
-        builder.statusText(statusLine[2]);
-
-        return builder.build();
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private String protocolVersion;
-        private String statusCode;
-        private String statusText;
-        private String contentType;
-        private int contentLength;
-
-        public Builder protocolVersion(String protocolVersion) {
-            this.protocolVersion = protocolVersion;
-            return this;
-        }
-
-        public Builder statusCode(String statusCode) {
-            this.statusCode = statusCode;
-            return this;
-        }
-
-        public Builder statusText(String statusText) {
-            this.statusText = statusText;
-            return this;
-        }
-
-        public Builder contentType(String contentType) {
-            this.contentType = contentType;
-            return this;
-        }
-
-        public Builder contentLength(int contentLength) {
-            this.contentLength = contentLength;
-            return this;
-        }
-
-        public Header build() {
-            return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
-        }
     }
 
     @Override
@@ -96,11 +14,11 @@ public class Header {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Header header = (Header) o;
-        return contentLength == header.contentLength && Objects.equals(protocolVersion, header.protocolVersion) && Objects.equals(statusCode, header.statusCode) && Objects.equals(statusText, header.statusText) && Objects.equals(contentType, header.contentType);
+        return Objects.equals(protocolVersion, header.protocolVersion);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(protocolVersion, statusCode, statusText, contentType, contentLength);
+        return Objects.hash(protocolVersion);
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,10 +1,10 @@
 package webserver;
 
 public class PostMessage {
-    private Header header;
+    private RequestHeader header;
     private Body body;
 
-    public PostMessage(Header header, Body body) {
+    public PostMessage(RequestHeader header, Body body) {
         this.header = header;
         this.body = body;
     }
@@ -12,10 +12,10 @@ public class PostMessage {
     public static PostMessage from(String postMessage) {
         String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
         //TODO body가 비어서 들어오는 경우 실제 form으로 테스트 해서 확인해볼 필요 있음
-        return new PostMessage(Header.of(splittedPostMessage[0], "request"), Body.from(splittedPostMessage[1]));
+        return new PostMessage(Header.requestHeaderFrom(splittedPostMessage[0]), Body.from(splittedPostMessage[1]));
     }
 
-    public Header getHeader() {
+    public RequestHeader getHeader() {
         return header;
     }
 
@@ -24,6 +24,6 @@ public class PostMessage {
     }
 
     public String getMethod() {
-        return ((RequestHeader) header).getMethod();
+        return header.getMethod();
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,6 +1,6 @@
 package webserver;
 
-public class PostMessage {
+public class PostMessage implements RequestMessage {
     private RequestHeader header;
     private Body body;
 
@@ -15,6 +15,7 @@ public class PostMessage {
         return new PostMessage(Header.requestHeaderFrom(splittedPostMessage[0]), Body.from(splittedPostMessage[1]));
     }
 
+    @Override
     public RequestHeader getHeader() {
         return header;
     }
@@ -23,6 +24,7 @@ public class PostMessage {
         return body;
     }
 
+    @Override
     public String getMethod() {
         return header.getMethod();
     }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -11,7 +11,7 @@ public class PostMessage {
 
     public static PostMessage from(String postMessage) {
         String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
-
+        //TODO body가 비어서 들어오는 경우 실제 form으로 테스트 해서 확인해볼 필요 있음
         return new PostMessage(Header.of(splittedPostMessage[0], "request"), Body.from(splittedPostMessage[1]));
     }
 
@@ -21,5 +21,9 @@ public class PostMessage {
 
     public Body getBody() {
         return body;
+    }
+
+    public String getMethod() {
+        return ((RequestHeader) header).getMethod();
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -40,7 +40,7 @@ public class PostMessage implements RequestMessage {
     @Override
     public Map<String, String> getParameters() {
         try {
-            String decode = URLDecoder.decode(body.asString(), StandardCharsets.UTF_8.name());
+            String decode = URLDecoder.decode(body.getString(), StandardCharsets.UTF_8.name());
             return HttpRequestUtils.parseQueryString(decode);
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("인코딩 오류", e);

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,5 +1,12 @@
 package webserver;
 
+import util.HttpRequestUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
 public class PostMessage implements RequestMessage {
     private RequestHeader header;
     private Body body;
@@ -27,5 +34,15 @@ public class PostMessage implements RequestMessage {
     @Override
     public String getMethod() {
         return header.getMethod();
+    }
+
+
+    public Map<String, String> getParameters() {
+        try {
+            String decode = URLDecoder.decode(body.asString(), StandardCharsets.UTF_8.name());
+            return HttpRequestUtils.parseQueryString(decode);
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("인코딩 오류", e);
+        }
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -36,7 +36,7 @@ public class PostMessage implements RequestMessage {
         return header.getMethod();
     }
 
-
+    @Override
     public Map<String, String> getParameters() {
         try {
             String decode = URLDecoder.decode(body.asString(), StandardCharsets.UTF_8.name());

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -6,6 +6,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
 public class PostMessage implements RequestMessage {
     private RequestHeader header;
@@ -44,5 +45,18 @@ public class PostMessage implements RequestMessage {
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("인코딩 오류", e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PostMessage that = (PostMessage) o;
+        return Objects.equals(header, that.header) && Objects.equals(body, that.body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(header, body);
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,0 +1,25 @@
+package webserver;
+
+public class PostMessage {
+    private Header header;
+    private Body body;
+
+    public PostMessage(Header header, Body body) {
+        this.header = header;
+        this.body = body;
+    }
+
+    public static PostMessage from(String postMessage) {
+        String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
+
+        return new PostMessage(Header.of(splittedPostMessage[0], "request"), Body.from(splittedPostMessage[1]));
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+
+    public Body getBody() {
+        return body;
+    }
+}

--- a/src/main/java/webserver/Request.java
+++ b/src/main/java/webserver/Request.java
@@ -1,0 +1,30 @@
+package webserver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+public class Request {
+    private RequestMessage requestMessage;
+
+    private Request(RequestMessage requestMessage) {
+        this.requestMessage = requestMessage;
+    }
+
+    public static Request from(InputStream inputStream){
+
+        try(BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))){
+            String message = br.lines().collect(Collectors.joining(System.lineSeparator()));
+
+            return new Request(RequestMessage.from(message));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("inputStream 이상함.",e);
+        }
+    }
+
+    public RequestMessage getRequestMessage() {
+        return requestMessage;
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,8 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +21,11 @@ public class RequestHandler extends Thread {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(in));
+
+            log.debug("Request Message:"+ br.lines().collect(Collectors.joining(System.lineSeparator())));
+
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
             byte[] body = "Hello World".getBytes();

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -10,6 +10,10 @@ public class RequestHeader extends Header {
         super(attributes);
     }
 
+    public String getMethod() {
+        return getStatusLineAttributes().get(METHOD_KEY);
+    }
+
     @Override
     protected void putStatusLine(String[] statusLine) {
         statusLineAttributes.put(METHOD_KEY, statusLine[0]);

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -2,6 +2,7 @@ package webserver;
 
 import util.HttpRequestUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -87,6 +88,28 @@ public class RequestHeader extends Header {
         public RequestHeader build() {
             return new RequestHeader(protocolVersion, cookie, method, path, host);
         }
+    }
+
+    private String startLine() {
+        return method + " " + path + " " + super.getProtocolVersion();
+    }
+
+    private String host() {
+        return "Host: " + host;
+    }
+
+    private String cookie() {
+        return "Cookie: " + cookie;
+    }
+
+    public byte[] toByte() {
+        return new StringBuilder()
+                .append(startLine()).append(System.lineSeparator())
+                .append(host()).append(System.lineSeparator())
+                .append(cookie()).append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .toString()
+                .getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -5,8 +5,9 @@ import java.util.List;
 import java.util.Map;
 
 public class RequestHeader extends Header {
+    public static final String PATH_KEY = "path";
+
     protected static final String METHOD_KEY = "method";
-    protected static final String PATH_KEY = "path";
 
     protected RequestHeader(Map<String, String> statusLineAttributes, Map<String, String> attributes) {
         super(statusLineAttributes, attributes);

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -1,0 +1,105 @@
+package webserver;
+
+import util.HttpRequestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class RequestHeader extends Header {
+    private String cookie;
+    private String method;
+    private String path;
+    private String host;
+
+    public RequestHeader(String protocolVersion, String cookie, String method, String path, String host) {
+        super(protocolVersion);
+        this.cookie = cookie;
+        this.method = method;
+        this.path = path;
+        this.host = host;
+    }
+
+    public static RequestHeader from(String headerText) {
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+
+        Builder builder = new Builder();
+        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
+
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
+
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null && pair.getKey().equals("Host")) {
+                builder.host(pair.getValue());
+            }
+            if (pair != null && pair.getKey().equals("Cookie")) {
+                builder.cookie(pair.getValue());
+            }
+        }
+
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        builder.method(statusLine[0]);
+        builder.path(statusLine[1]);
+        builder.protocolVersion(statusLine[2]);
+
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String protocolVersion;
+        private String cookie;
+        private String method;
+        private String path;
+        private String host;
+
+        public Builder protocolVersion(String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder cookie(String cookie) {
+            this.cookie = cookie;
+            return this;
+        }
+
+        public Builder method(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public RequestHeader build() {
+            return new RequestHeader(protocolVersion, cookie, method, path, host);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RequestHeader that = (RequestHeader) o;
+        return Objects.equals(cookie, that.cookie) && Objects.equals(method, that.method) && Objects.equals(path, that.path) && Objects.equals(host, that.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cookie, method, path, host);
+    }
+}

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -1,24 +1,29 @@
 package webserver;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class RequestHeader extends Header {
-    private static final String METHOD_KEY = "method";
-    private static final String PATH_KEY = "path";
+    protected static final String METHOD_KEY = "method";
+    protected static final String PATH_KEY = "path";
 
-    protected RequestHeader(Map<String, String> attributes) {
-        super(attributes);
+    protected RequestHeader(Map<String, String> statusLineAttributes, Map<String, String> attributes) {
+        super(statusLineAttributes, attributes);
+    }
+
+    public static RequestHeader of(List<String> statusLine, Map<String, String> attributes) {
+        Map<String, String> statusLineAttributes = new HashMap<>();
+
+        statusLineAttributes.put(METHOD_KEY, statusLine.get(0));
+        statusLineAttributes.put(PATH_KEY, statusLine.get(1));
+        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(2));
+
+        return new RequestHeader(statusLineAttributes, attributes);
     }
 
     public String getMethod() {
         return getStatusLineAttributes().get(METHOD_KEY);
-    }
-
-    @Override
-    protected void putStatusLine(String[] statusLine) {
-        statusLineAttributes.put(METHOD_KEY, statusLine[0]);
-        statusLineAttributes.put(PATH_KEY, statusLine[1]);
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine[2]);
     }
 
     @Override

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -6,7 +6,7 @@ public class RequestHeader extends Header {
     private static final String METHOD_KEY = "method";
     private static final String PATH_KEY = "path";
 
-    public RequestHeader(Map<String, String> attributes) {
+    protected RequestHeader(Map<String, String> attributes) {
         super(attributes);
     }
 

--- a/src/main/java/webserver/RequestMessage.java
+++ b/src/main/java/webserver/RequestMessage.java
@@ -1,0 +1,7 @@
+package webserver;
+
+public interface RequestMessage {
+    RequestHeader getHeader();
+
+    String getMethod();
+}

--- a/src/main/java/webserver/RequestMessage.java
+++ b/src/main/java/webserver/RequestMessage.java
@@ -3,6 +3,16 @@ package webserver;
 import java.util.Map;
 
 public interface RequestMessage {
+    static RequestMessage from(String message) {
+        RequestHeader header = Header.requestHeaderFrom(message.split(System.lineSeparator())[0]);
+
+        if (header.getMethod().equalsIgnoreCase("post")) {
+            return PostMessage.from(message);
+        }
+        
+        return GetMessage.from(message);
+    }
+
     RequestHeader getHeader();
 
     String getMethod();

--- a/src/main/java/webserver/RequestMessage.java
+++ b/src/main/java/webserver/RequestMessage.java
@@ -1,7 +1,11 @@
 package webserver;
 
+import java.util.Map;
+
 public interface RequestMessage {
     RequestHeader getHeader();
 
     String getMethod();
+
+    Map<String, String> getParameters();
 }

--- a/src/main/java/webserver/Response.java
+++ b/src/main/java/webserver/Response.java
@@ -1,0 +1,42 @@
+package webserver;
+
+import java.io.*;
+import java.util.Objects;
+
+public class Response {
+    private ResponseMessage responseMessage;
+
+    public Response(ResponseMessage responseMessage) {
+        this.responseMessage = responseMessage;
+    }
+
+    public static Response from(String message) {
+        return new Response(ResponseMessage.from(message));
+    }
+
+    public void write(OutputStream outputStream) {
+        try (DataOutputStream dos = new DataOutputStream(outputStream)) {
+            byte[] header = responseMessage.getHeader().getBytes();
+            byte[] body = responseMessage.getBody().getBytes();
+
+            dos.write(header);
+            dos.write(body);
+            dos.flush();
+        } catch (IOException e) {
+            throw new IllegalStateException("Response 출력오류", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Response response = (Response) o;
+        return Objects.equals(responseMessage, response.responseMessage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(responseMessage);
+    }
+}

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -6,7 +6,7 @@ public class ResponseHeader extends Header {
     private static final String STATUS_CODE_KEY = "statusCode";
     private static final String STATUS_TEXT_KEY = "statusText";
 
-    public ResponseHeader(Map<String, String> attributes) {
+    protected ResponseHeader(Map<String, String> attributes) {
         super(attributes);
     }
 

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -1,0 +1,105 @@
+package webserver;
+
+import util.HttpRequestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ResponseHeader extends Header {
+    private String statusCode;
+    private String statusText;
+    private String contentType;
+    private int contentLength;
+
+    public ResponseHeader(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
+        super(protocolVersion);
+        this.statusCode = statusCode;
+        this.statusText = statusText;
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+    }
+
+    public static Header from(String headerText) {
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+
+        Builder builder = new Builder();
+        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
+
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
+
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null && pair.getKey().equals("Content-Type")) {
+                builder.contentType(pair.getValue());
+            }
+            if (pair != null && pair.getKey().equals("Content-Length")) {
+                builder.contentLength(Integer.parseInt(pair.getValue()));
+            }
+        }
+
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        builder.protocolVersion(statusLine[0]);
+        builder.statusCode(statusLine[1]);
+        builder.statusText(statusLine[2]);
+
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String protocolVersion;
+        private String statusCode;
+        private String statusText;
+        private String contentType;
+        private int contentLength;
+
+        public Builder protocolVersion(String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder statusCode(String statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder statusText(String statusText) {
+            this.statusText = statusText;
+            return this;
+        }
+
+        public Builder contentType(String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public Builder contentLength(int contentLength) {
+            this.contentLength = contentLength;
+            return this;
+        }
+
+        public ResponseHeader build() {
+            return new ResponseHeader(protocolVersion, statusCode, statusText, contentType, contentLength);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ResponseHeader that = (ResponseHeader) o;
+        return contentLength == that.contentLength && Objects.equals(statusCode, that.statusCode) && Objects.equals(statusText, that.statusText) && Objects.equals(contentType, that.contentType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), statusCode, statusText, contentType, contentLength);
+    }
+}

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -1,20 +1,25 @@
 package webserver;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ResponseHeader extends Header {
-    private static final String STATUS_CODE_KEY = "statusCode";
-    private static final String STATUS_TEXT_KEY = "statusText";
+    protected static final String STATUS_CODE_KEY = "statusCode";
+    protected static final String STATUS_TEXT_KEY = "statusText";
 
-    protected ResponseHeader(Map<String, String> attributes) {
-        super(attributes);
+    protected ResponseHeader(Map<String, String> statusLineAttributes, Map<String, String> attributes) {
+        super(statusLineAttributes, attributes);
     }
 
-    @Override
-    protected void putStatusLine(String[] statusLine) {
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine[0]);
-        statusLineAttributes.put(STATUS_CODE_KEY, statusLine[1]);
-        statusLineAttributes.put(STATUS_TEXT_KEY, statusLine[2]);
+    public static ResponseHeader of(List<String> statusLine, Map<String, String> attributes) {
+        Map<String, String> statusLineAttributes = new HashMap<>();
+
+        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(0));
+        statusLineAttributes.put(STATUS_CODE_KEY, statusLine.get(1));
+        statusLineAttributes.put(STATUS_TEXT_KEY, statusLine.get(2));
+
+        return new ResponseHeader(statusLineAttributes, attributes);
     }
 
     @Override

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -1,128 +1,24 @@
 package webserver;
 
-import util.HttpRequestUtils;
-
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 public class ResponseHeader extends Header {
-    private String statusCode;
-    private String statusText;
-    private String contentType;
-    private int contentLength;
+    private static final String STATUS_CODE_KEY = "statusCode";
+    private static final String STATUS_TEXT_KEY = "statusText";
 
-    public ResponseHeader(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
-        super(protocolVersion);
-        this.statusCode = statusCode;
-        this.statusText = statusText;
-        this.contentType = contentType;
-        this.contentLength = contentLength;
-    }
-
-    public static ResponseHeader from(String headerText) {
-        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
-
-        Builder builder = new Builder();
-        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
-
-        for (String splittedHeaderText : splittedHeaderTexts) {
-            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
-
-            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
-
-            if (pair != null && pair.getKey().equals("Content-Type")) {
-                builder.contentType(pair.getValue());
-            }
-            if (pair != null && pair.getKey().equals("Content-Length")) {
-                builder.contentLength(Integer.parseInt(pair.getValue()));
-            }
-        }
-
-        String[] statusLine = splittedHeaderTexts[0].split(" ");
-
-        builder.protocolVersion(statusLine[0]);
-        builder.statusCode(statusLine[1]);
-        builder.statusText(statusLine[2]);
-
-        return builder.build();
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private String protocolVersion;
-        private String statusCode;
-        private String statusText;
-        private String contentType;
-        private int contentLength;
-
-        public Builder protocolVersion(String protocolVersion) {
-            this.protocolVersion = protocolVersion;
-            return this;
-        }
-
-        public Builder statusCode(String statusCode) {
-            this.statusCode = statusCode;
-            return this;
-        }
-
-        public Builder statusText(String statusText) {
-            this.statusText = statusText;
-            return this;
-        }
-
-        public Builder contentType(String contentType) {
-            this.contentType = contentType;
-            return this;
-        }
-
-        public Builder contentLength(int contentLength) {
-            this.contentLength = contentLength;
-            return this;
-        }
-
-        public ResponseHeader build() {
-            return new ResponseHeader(protocolVersion, statusCode, statusText, contentType, contentLength);
-        }
-    }
-
-    private String statusLine() {
-        return super.getProtocolVersion() + " " + statusCode + " " + statusText + " ";
-    }
-
-    private String contentType() {
-        return "Content-Type: " + contentType;
-    }
-
-    private String contentLength() {
-        return "Content-Length: " + contentLength;
-    }
-
-    public byte[] toByte() {
-        return new StringBuilder()
-                .append(statusLine()).append(System.lineSeparator())
-                .append(contentType()).append(System.lineSeparator())
-                .append(contentLength()).append(System.lineSeparator())
-                .append(System.lineSeparator())
-                .toString()
-                .getBytes(StandardCharsets.UTF_8);
+    public ResponseHeader(Map<String, String> attributes) {
+        super(attributes);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        ResponseHeader that = (ResponseHeader) o;
-        return contentLength == that.contentLength && Objects.equals(statusCode, that.statusCode) && Objects.equals(statusText, that.statusText) && Objects.equals(contentType, that.contentType);
+    protected void putStatusLine(String[] statusLine) {
+        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine[0]);
+        statusLineAttributes.put(STATUS_CODE_KEY, statusLine[1]);
+        statusLineAttributes.put(STATUS_TEXT_KEY, statusLine[2]);
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), statusCode, statusText, contentType, contentLength);
+    protected String statusLine() {
+        return statusLineAttributes.get(PROTOCOL_VERSION_KEY) + " " + statusLineAttributes.get(STATUS_CODE_KEY) + " " + statusLineAttributes.get(STATUS_TEXT_KEY);
     }
 }

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -2,6 +2,7 @@ package webserver;
 
 import util.HttpRequestUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -20,7 +21,7 @@ public class ResponseHeader extends Header {
         this.contentLength = contentLength;
     }
 
-    public static Header from(String headerText) {
+    public static ResponseHeader from(String headerText) {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
 
         Builder builder = new Builder();
@@ -87,6 +88,28 @@ public class ResponseHeader extends Header {
         public ResponseHeader build() {
             return new ResponseHeader(protocolVersion, statusCode, statusText, contentType, contentLength);
         }
+    }
+
+    private String statusLine() {
+        return super.getProtocolVersion() + " " + statusCode + " " + statusText + " ";
+    }
+
+    private String contentType() {
+        return "Content-Type: " + contentType;
+    }
+
+    private String contentLength() {
+        return "Content-Length: " + contentLength;
+    }
+
+    public byte[] toByte() {
+        return new StringBuilder()
+                .append(statusLine()).append(System.lineSeparator())
+                .append(contentType()).append(System.lineSeparator())
+                .append(contentLength()).append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .toString()
+                .getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/main/java/webserver/ResponseMessage.java
+++ b/src/main/java/webserver/ResponseMessage.java
@@ -1,5 +1,7 @@
 package webserver;
 
+import java.util.Objects;
+
 public class ResponseMessage {
     private ResponseHeader header;
     private Body body;
@@ -21,5 +23,18 @@ public class ResponseMessage {
 
     public Body getBody() {
         return body;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResponseMessage that = (ResponseMessage) o;
+        return Objects.equals(header, that.header) && Objects.equals(body, that.body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(header, body);
     }
 }

--- a/src/main/java/webserver/ResponseMessage.java
+++ b/src/main/java/webserver/ResponseMessage.java
@@ -1,0 +1,25 @@
+package webserver;
+
+public class ResponseMessage {
+    private Header header;
+    private Body body;
+
+    public ResponseMessage(Header header, Body body) {
+        this.header = header;
+        this.body = body;
+    }
+
+    public static ResponseMessage from(String responseMessage) {
+        String[] splittedResponseMessage = responseMessage.split(System.lineSeparator() + System.lineSeparator());
+
+        return new ResponseMessage(Header.of(splittedResponseMessage[0], "response"), Body.from(splittedResponseMessage[1]));
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+
+    public Body getBody() {
+        return body;
+    }
+}

--- a/src/main/java/webserver/ResponseMessage.java
+++ b/src/main/java/webserver/ResponseMessage.java
@@ -1,10 +1,10 @@
 package webserver;
 
 public class ResponseMessage {
-    private Header header;
+    private ResponseHeader header;
     private Body body;
 
-    public ResponseMessage(Header header, Body body) {
+    public ResponseMessage(ResponseHeader header, Body body) {
         this.header = header;
         this.body = body;
     }
@@ -12,10 +12,10 @@ public class ResponseMessage {
     public static ResponseMessage from(String responseMessage) {
         String[] splittedResponseMessage = responseMessage.split(System.lineSeparator() + System.lineSeparator());
 
-        return new ResponseMessage(Header.of(splittedResponseMessage[0], "response"), Body.from(splittedResponseMessage[1]));
+        return new ResponseMessage(Header.responseHeaderFrom(splittedResponseMessage[0]), Body.from(splittedResponseMessage[1]));
     }
 
-    public Header getHeader() {
+    public ResponseHeader getHeader() {
         return header;
     }
 

--- a/src/test/java/util/HttpRequestUtilsTest.java
+++ b/src/test/java/util/HttpRequestUtilsTest.java
@@ -68,18 +68,20 @@ class HttpRequestUtilsTest {
 
     @ParameterizedTest
     @MethodSource
-    void parseCookies(String cookies, String expectedParameterName, String expectedParameterValue) {
+    void parseCookies(String cookies, String expectedLogined, String expectedJSessionId, String expectedSession) {
         Map<String, String> parameters = HttpRequestUtils.parseCookies(cookies);
 
-        assertThat(parameters.get(expectedParameterName)).isEqualTo(expectedParameterValue);
+        assertAll(
+                () -> assertThat(parameters.get("logined")).isEqualTo(expectedLogined),
+                () -> assertThat(parameters.get("JSessionId")).isEqualTo(expectedJSessionId),
+                () -> assertThat(parameters.get("session")).isEqualTo(expectedSession)
+        );
     }
 
     @SuppressWarnings("unused")
     static Stream<Arguments> parseCookies() {
         return Stream.of(
-                Arguments.of("logined=true; JSessionId=1234", "logined", "true"),
-                Arguments.of("logined=true; JSessionId=1234", "JSessionId", "1234"),
-                Arguments.of("logined=true; JSessionId=1234", "session", null)
+                Arguments.of("logined=true; JSessionId=1234", "true", "1234", null)
         );
     }
 

--- a/src/test/java/util/HttpRequestUtilsTest.java
+++ b/src/test/java/util/HttpRequestUtilsTest.java
@@ -1,72 +1,133 @@
 package util;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import util.HttpRequestUtils.Pair;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 
 class HttpRequestUtilsTest {
-    @Test
-    void parseQueryString() {
-        String queryString = "userId=javajigi";
+    @ParameterizedTest
+    @MethodSource
+    void parseQueryString(String queryString, String expectedUserId, String expectedPassword) {
         Map<String, String> parameters = HttpRequestUtils.parseQueryString(queryString);
-        assertThat(parameters.get("userId")).isEqualTo(("javajigi"));
-        assertThat(parameters.get("password")).isNull();
 
-        queryString = "userId=javajigi&password=password2";
-        parameters = HttpRequestUtils.parseQueryString(queryString);
-        assertThat(parameters.get("userId")).isEqualTo(("javajigi"));
-        assertThat(parameters.get("password")).isEqualTo("password2");
+        assertAll(
+                () -> assertThat(parameters.get("userId")).isEqualTo(expectedUserId),
+                () -> assertThat(parameters.get("password")).isEqualTo(expectedPassword)
+        );
     }
 
-    @Test
-    void parseQueryString_null() {
-        Map<String, String> parameters = HttpRequestUtils.parseQueryString(null);
-        assertThat(parameters.isEmpty()).isTrue();
+    @SuppressWarnings("unused")
+    static Stream<Arguments> parseQueryString() {
+        return Stream.of(
+                Arguments.of("userId=javajigi", "javajigi", null),
+                Arguments.of("userId=javajigi&password=password2", "javajigi", "password2")
+        );
+    }
 
-        parameters = HttpRequestUtils.parseQueryString("");
-        assertThat(parameters.isEmpty()).isTrue();
-
-        parameters = HttpRequestUtils.parseQueryString(" ");
+    @ParameterizedTest
+    @MethodSource
+    void parseQueryString_null(Map<String, String> parameters) {
         assertThat(parameters.isEmpty()).isTrue();
     }
 
-    @Test
-    void parseQueryString_invalid() {
-        String queryString = "userId=javajigi&password";
+    @SuppressWarnings("unused")
+    static Stream<Arguments> parseQueryString_null() {
+        return Stream.of(
+                Arguments.of(HttpRequestUtils.parseQueryString(null)),
+                Arguments.of(HttpRequestUtils.parseQueryString("")),
+                Arguments.of(HttpRequestUtils.parseQueryString(" "))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parseQueryString_invalid(String queryString, String expectedUserId, String expectedPassword) {
         Map<String, String> parameters = HttpRequestUtils.parseQueryString(queryString);
-        assertThat(parameters.get("userId")).isEqualTo("javajigi");
-        assertThat(parameters.get("password")).isNull();
+
+        assertAll(
+                () -> assertThat(parameters.get("userId")).isEqualTo(expectedUserId),
+                () -> assertThat(parameters.get("password")).isEqualTo(expectedPassword)
+        );
     }
 
-    @Test
-    void parseCookies() {
-        String cookies = "logined=true; JSessionId=1234";
+    @SuppressWarnings("unused")
+    static Stream<Arguments> parseQueryString_invalid() {
+        return Stream.of(
+                Arguments.of("userId=javajigi&password", "javajigi", null)
+        );
+    }
+
+
+    @ParameterizedTest
+    @MethodSource
+    void parseCookies(String cookies, String expectedParameterName, String expectedParameterValue) {
         Map<String, String> parameters = HttpRequestUtils.parseCookies(cookies);
-        assertThat(parameters.get("logined")).isEqualTo("true");
-        assertThat(parameters.get("JSessionId")).isEqualTo("1234");
-        assertThat(parameters.get("session")).isNull();
+
+        assertThat(parameters.get(expectedParameterName)).isEqualTo(expectedParameterValue);
     }
 
-    @Test
-    void getKeyValue(){
-        Pair pair = HttpRequestUtils.getKeyValue("userId=javajigi", "=");
-        assertThat(pair).isEqualTo(new Pair("userId", "javajigi"));
+    @SuppressWarnings("unused")
+    static Stream<Arguments> parseCookies() {
+        return Stream.of(
+                Arguments.of("logined=true; JSessionId=1234", "logined", "true"),
+                Arguments.of("logined=true; JSessionId=1234", "JSessionId", "1234"),
+                Arguments.of("logined=true; JSessionId=1234", "session", null)
+        );
     }
 
-    @Test
-    void getKeyValue_invalid(){
-        Pair pair = HttpRequestUtils.getKeyValue("userId", "=");
-        assertThat(pair).isNull();
+    @ParameterizedTest
+    @MethodSource
+    void getKeyValue(Pair pair, Pair expectedPair) {
+        assertThat(pair).isEqualTo(expectedPair);
     }
 
-    @Test
-    void parseHeader(){
-        String header = "Content-Length: 59";
-        Pair pair = HttpRequestUtils.parseHeader(header);
-        assertThat(pair).isEqualTo(new Pair("Content-Length", "59"));
+    @SuppressWarnings("unused")
+    static Stream<Arguments> getKeyValue() {
+        return Stream.of(
+                Arguments.of(
+                        HttpRequestUtils.getKeyValue("userId=javajigi", "="),
+                        new Pair("userId", "javajigi")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getKeyValue_invalid(Pair pair, Pair expectedPair) {
+        assertThat(pair).isEqualTo(expectedPair);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> getKeyValue_invalid() {
+        return Stream.of(
+                Arguments.of(
+                        HttpRequestUtils.getKeyValue("userId", "="),
+                        null
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parseHeader(Pair pair, Pair expectedPair) {
+        assertThat(pair).isEqualTo(expectedPair);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> parseHeader() {
+        return Stream.of(
+                Arguments.of(
+                        HttpRequestUtils.parseHeader("Content-Length: 59"),
+                        new Pair("Content-Length", "59")
+                )
+        );
     }
 }

--- a/src/test/java/util/HttpRequestUtilsTest.java
+++ b/src/test/java/util/HttpRequestUtilsTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import util.HttpRequestUtils.Pair;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -64,6 +66,7 @@ class HttpRequestUtilsTest {
                 Arguments.of("userId=javajigi&password", "javajigi", null)
         );
     }
+
     @ParameterizedTest
     @MethodSource
     void parseCookies(String cookies, String expectedLogined, String expectedJSessionId, String expectedSession) {
@@ -127,6 +130,21 @@ class HttpRequestUtilsTest {
                 Arguments.of(
                         HttpRequestUtils.parseHeader("Content-Length: 59"),
                         new Pair("Content-Length", "59")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parseStatusLine(String statusLine, List<String> expectedParsedStatusLine) {
+        assertThat(HttpRequestUtils.parseStatusLine(statusLine)).isEqualTo(expectedParsedStatusLine);
+    }
+
+    static Stream<Arguments> parseStatusLine() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create HTTP/1.1",
+                        Arrays.asList("GET", "/user/create", "HTTP/1.1")
                 )
         );
     }

--- a/src/test/java/util/HttpRequestUtilsTest.java
+++ b/src/test/java/util/HttpRequestUtilsTest.java
@@ -64,8 +64,6 @@ class HttpRequestUtilsTest {
                 Arguments.of("userId=javajigi&password", "javajigi", null)
         );
     }
-
-
     @ParameterizedTest
     @MethodSource
     void parseCookies(String cookies, String expectedLogined, String expectedJSessionId, String expectedSession) {

--- a/src/test/java/util/HttpRequestUtilsTest.java
+++ b/src/test/java/util/HttpRequestUtilsTest.java
@@ -1,73 +1,72 @@
 package util;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import util.HttpRequestUtils.Pair;
 
 import java.util.Map;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import util.HttpRequestUtils.Pair;
 
-public class HttpRequestUtilsTest {
+class HttpRequestUtilsTest {
     @Test
-    public void parseQueryString() {
+    void parseQueryString() {
         String queryString = "userId=javajigi";
         Map<String, String> parameters = HttpRequestUtils.parseQueryString(queryString);
-        assertThat(parameters.get("userId"), is("javajigi"));
-        assertThat(parameters.get("password"), is(nullValue()));
+        assertThat(parameters.get("userId")).isEqualTo(("javajigi"));
+        assertThat(parameters.get("password")).isNull();
 
         queryString = "userId=javajigi&password=password2";
         parameters = HttpRequestUtils.parseQueryString(queryString);
-        assertThat(parameters.get("userId"), is("javajigi"));
-        assertThat(parameters.get("password"), is("password2"));
+        assertThat(parameters.get("userId")).isEqualTo(("javajigi"));
+        assertThat(parameters.get("password")).isEqualTo("password2");
     }
 
     @Test
-    public void parseQueryString_null() {
+    void parseQueryString_null() {
         Map<String, String> parameters = HttpRequestUtils.parseQueryString(null);
-        assertThat(parameters.isEmpty(), is(true));
+        assertThat(parameters.isEmpty()).isTrue();
 
         parameters = HttpRequestUtils.parseQueryString("");
-        assertThat(parameters.isEmpty(), is(true));
+        assertThat(parameters.isEmpty()).isTrue();
 
         parameters = HttpRequestUtils.parseQueryString(" ");
-        assertThat(parameters.isEmpty(), is(true));
+        assertThat(parameters.isEmpty()).isTrue();
     }
 
     @Test
-    public void parseQueryString_invalid() {
+    void parseQueryString_invalid() {
         String queryString = "userId=javajigi&password";
         Map<String, String> parameters = HttpRequestUtils.parseQueryString(queryString);
-        assertThat(parameters.get("userId"), is("javajigi"));
-        assertThat(parameters.get("password"), is(nullValue()));
+        assertThat(parameters.get("userId")).isEqualTo("javajigi");
+        assertThat(parameters.get("password")).isNull();
     }
 
     @Test
-    public void parseCookies() {
+    void parseCookies() {
         String cookies = "logined=true; JSessionId=1234";
         Map<String, String> parameters = HttpRequestUtils.parseCookies(cookies);
-        assertThat(parameters.get("logined"), is("true"));
-        assertThat(parameters.get("JSessionId"), is("1234"));
-        assertThat(parameters.get("session"), is(nullValue()));
+        assertThat(parameters.get("logined")).isEqualTo("true");
+        assertThat(parameters.get("JSessionId")).isEqualTo("1234");
+        assertThat(parameters.get("session")).isNull();
     }
 
     @Test
-    public void getKeyValue() throws Exception {
+    void getKeyValue(){
         Pair pair = HttpRequestUtils.getKeyValue("userId=javajigi", "=");
-        assertThat(pair, is(new Pair("userId", "javajigi")));
+        assertThat(pair).isEqualTo(new Pair("userId", "javajigi"));
     }
 
     @Test
-    public void getKeyValue_invalid() throws Exception {
+    void getKeyValue_invalid(){
         Pair pair = HttpRequestUtils.getKeyValue("userId", "=");
-        assertThat(pair, is(nullValue()));
+        assertThat(pair).isNull();
     }
 
     @Test
-    public void parseHeader() throws Exception {
+    void parseHeader(){
         String header = "Content-Length: 59";
         Pair pair = HttpRequestUtils.parseHeader(header);
-        assertThat(pair, is(new Pair("Content-Length", "59")));
+        assertThat(pair).isEqualTo(new Pair("Content-Length", "59"));
     }
 }

--- a/src/test/java/util/IOUtilsTest.java
+++ b/src/test/java/util/IOUtilsTest.java
@@ -1,17 +1,17 @@
 package util;
 
-import java.io.BufferedReader;
-import java.io.StringReader;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class IOUtilsTest {
+import java.io.BufferedReader;
+import java.io.StringReader;
+
+class IOUtilsTest {
     private static final Logger logger = LoggerFactory.getLogger(IOUtilsTest.class);
 
     @Test
-    public void readData() throws Exception {
+    void readData() throws Exception {
         String data = "abcd123";
         StringReader sr = new StringReader(data);
         BufferedReader br = new BufferedReader(sr);

--- a/src/test/java/util/IOUtilsTest.java
+++ b/src/test/java/util/IOUtilsTest.java
@@ -1,21 +1,33 @@
 package util;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class IOUtilsTest {
     private static final Logger logger = LoggerFactory.getLogger(IOUtilsTest.class);
 
-    @Test
-    void readData() throws Exception {
-        String data = "abcd123";
+    @ParameterizedTest
+    @MethodSource
+    void readData(String data, String expectedData) throws Exception {
         StringReader sr = new StringReader(data);
         BufferedReader br = new BufferedReader(sr);
 
-        logger.debug("parse body : {}", IOUtils.readData(br, data.length()));
+        assertThat(IOUtils.readData(br, data.length())).isEqualTo(expectedData);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> readData() {
+        return Stream.of(
+                Arguments.of("abcd123", "abcd123")
+        );
     }
 }

--- a/src/test/java/util/IOUtilsTest.java
+++ b/src/test/java/util/IOUtilsTest.java
@@ -13,7 +13,6 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class IOUtilsTest {
-    private static final Logger logger = LoggerFactory.getLogger(IOUtilsTest.class);
 
     @ParameterizedTest
     @MethodSource

--- a/src/test/java/webserver/BodyTest.java
+++ b/src/test/java/webserver/BodyTest.java
@@ -1,0 +1,14 @@
+package webserver;
+
+import org.junit.jupiter.api.Test;
+
+class BodyTest {
+
+    @Test
+    void init() {
+        String data = "Hello World";
+        Body expected = Body.create(data);
+
+        Body body = Body.create(data);
+    }
+}

--- a/src/test/java/webserver/BodyTest.java
+++ b/src/test/java/webserver/BodyTest.java
@@ -9,9 +9,9 @@ class BodyTest {
     @Test
     void init() {
         String data = "Hello World";
-        Body expectedBody = Body.create(data);
+        Body expectedBody = Body.from(data);
 
-        Body body = Body.create(data);
+        Body body = Body.from(data);
 
         assertThat(body).isEqualTo(expectedBody);
     }

--- a/src/test/java/webserver/BodyTest.java
+++ b/src/test/java/webserver/BodyTest.java
@@ -2,13 +2,17 @@ package webserver;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 class BodyTest {
 
     @Test
     void init() {
         String data = "Hello World";
-        Body expected = Body.create(data);
+        Body expectedBody = Body.create(data);
 
         Body body = Body.create(data);
+
+        assertThat(body).isEqualTo(expectedBody);
     }
 }

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -55,6 +57,34 @@ class GetMessageTest {
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(),
                         "GET"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getParameters(String messageText, Map<String, String> expectedParameters) {
+        GetMessage getMessage = GetMessage.from(messageText);
+        assertThat(getMessage.getParameters())
+                .isEqualTo(expectedParameters);
+    }
+
+    static Stream<Arguments> getParameters() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(),
+                        new HashMap() {{
+                            put("userId", "javajigi");
+                            put("password", "password");
+                            put("name", "박재성");
+                            put("email", "javajigi@slipp.net");
+                        }}
                 )
         );
     }

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class GetMessageTest {
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getHeader")
     void getHeader(String messageText, RequestHeader expectedRequestHeader) {
         GetMessage getMessage = GetMessage.from(messageText);
 
@@ -41,7 +41,7 @@ class GetMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getMethod")
     void getMethod(String messageText, String expectedRequestMethod) {
         GetMessage getMessage = GetMessage.from(messageText);
         assertThat(getMessage.getMethod()).isEqualTo(expectedRequestMethod);
@@ -62,7 +62,7 @@ class GetMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getParameters")
     void getParameters(String messageText, Map<String, String> expectedParameters) {
         GetMessage getMessage = GetMessage.from(messageText);
         assertThat(getMessage.getParameters())
@@ -79,7 +79,7 @@ class GetMessageTest {
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(),
-                        new HashMap() {{
+                        new HashMap<String, String>() {{
                             put("userId", "javajigi");
                             put("password", "password");
                             put("name", "박재성");

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -27,13 +27,13 @@ class GetMessageTest {
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(),
-                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                        Header.requestHeaderFrom("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
                                 "Content-Length: 59" + System.lineSeparator() +
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator(), "request")
+                                "" + System.lineSeparator())
                 )
         );
     }

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -1,0 +1,39 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class GetMessageTest {
+    @ParameterizedTest
+    @MethodSource
+    void getHeader(String messageText, RequestHeader expectedRequestHeader) {
+        GetMessage getMessage = GetMessage.from(messageText);
+
+        assertThat(getMessage.getHeader()).isEqualTo(expectedRequestHeader);
+    }
+
+    static Stream<Arguments> getHeader() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(),
+                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(), "request")
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -19,6 +19,7 @@ class GetMessageTest {
 
     static Stream<Arguments> getHeader() {
         return Stream.of(
+                //TODO getMessage인데 POST가  성공하는 테스트케이스로 들어가 있음!
                 Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
@@ -33,6 +34,27 @@ class GetMessageTest {
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(), "request")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getMethod(String messageText, String expectedRequestMethod) {
+        GetMessage getMessage = GetMessage.from(messageText);
+        assertThat(getMessage.getMethod()).isEqualTo(expectedRequestMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of("GET /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(),
+                        "GET"
                 )
         );
     }

--- a/src/test/java/webserver/HeaderTest.java
+++ b/src/test/java/webserver/HeaderTest.java
@@ -1,38 +1,4 @@
 package webserver;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class HeaderTest {
-
-    @ParameterizedTest
-    @MethodSource
-    void from(String headerText, Header expectedHeader) {
-        assertThat(Header.from(headerText))
-                .isEqualTo(expectedHeader);
-    }
-
-    @SuppressWarnings("unused")
-    static Stream<Arguments> from() {
-        return Stream.of(
-                Arguments.of(
-                        "HTTP/1.1 200 OK " + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                                System.lineSeparator(),
-                        Header.builder()
-                                .protocolVersion("HTTP/1.1")
-                                .statusCode("200")
-                                .statusText("OK")
-                                .contentType("text/html;charset=utf-8")
-                                .contentLength("Hello World".getBytes().length)
-                                .build()
-                )
-        );
-    }
 }

--- a/src/test/java/webserver/HeaderTest.java
+++ b/src/test/java/webserver/HeaderTest.java
@@ -25,14 +25,13 @@ class HeaderTest {
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-//                        Header.builder()
-//                                .protocolVersion("HTTP/1.1")
-//                                .statusCode("200")
-//                                .statusText("OK")
-//                                .contentType("text/html;charset=utf-8")
-//                                .contentLength("Hello World".getL())
-//                                .build()
-                        new Header("HTTP/1.1", "200", "OK", "text/html;charset=utf-8", "Hello World".getBytes().length)
+                        Header.builder()
+                                .protocolVersion("HTTP/1.1")
+                                .statusCode("200")
+                                .statusText("OK")
+                                .contentType("text/html;charset=utf-8")
+                                .contentLength("Hello World".getBytes().length)
+                                .build()
                 )
         );
     }

--- a/src/test/java/webserver/HeaderTest.java
+++ b/src/test/java/webserver/HeaderTest.java
@@ -1,0 +1,39 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HeaderTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void from(String headerText, Header expectedHeader) {
+        assertThat(Header.from(headerText))
+                .isEqualTo(expectedHeader);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+//                        Header.builder()
+//                                .protocolVersion("HTTP/1.1")
+//                                .statusCode("200")
+//                                .statusText("OK")
+//                                .contentType("text/html;charset=utf-8")
+//                                .contentLength("Hello World".getL())
+//                                .build()
+                        new Header("HTTP/1.1", "200", "OK", "text/html;charset=utf-8", "Hello World".getBytes().length)
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -28,13 +28,13 @@ class PostMessageTest {
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator() +
                                 "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
-                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                        Header.requestHeaderFrom("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
                                 "Content-Length: 59" + System.lineSeparator() +
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator(), "request")
+                                "" + System.lineSeparator())
                 )
         );
     }

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -61,4 +61,26 @@ class PostMessageTest {
                 )
         );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void getMethod(String messageText, String expectedRequestMethod) {
+        PostMessage postMessage = PostMessage.from(messageText);
+        assertThat(postMessage.getMethod()).isEqualTo(expectedRequestMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        "POST"
+                )
+        );
+    }
 }

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -1,0 +1,64 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class PostMessageTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void getRequestHeader(String messageText, RequestHeader expectedRequestHeader) {
+        PostMessage postMessage = PostMessage.from(messageText);
+
+        assertThat(postMessage.getHeader()).isEqualTo(expectedRequestHeader);
+    }
+
+    static Stream<Arguments> getRequestHeader() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
+                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(), "request")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getBody(String messageText, Body expectedBody) {
+        PostMessage postMessage = PostMessage.from(messageText);
+
+        assertThat(postMessage.getBody()).isEqualTo(expectedBody);
+    }
+
+    static Stream<Arguments> getBody() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
+                        Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator())
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class PostMessageTest {
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getHeader")
     void getHeader(String messageText, RequestHeader expectedRequestHeader) {
         PostMessage postMessage = PostMessage.from(messageText);
 
@@ -40,7 +40,7 @@ class PostMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getBody")
     void getBody(String messageText, Body expectedBody) {
         PostMessage postMessage = PostMessage.from(messageText);
 
@@ -63,7 +63,7 @@ class PostMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getMethod")
     void getMethod(String messageText, String expectedRequestMethod) {
         PostMessage postMessage = PostMessage.from(messageText);
         assertThat(postMessage.getMethod()).isEqualTo(expectedRequestMethod);

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -80,6 +82,34 @@ class PostMessageTest {
                                 "" + System.lineSeparator() +
                                 "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                         "POST"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    void getParameters(String messageText, Map<String, String> expectedParameters) {
+        PostMessage postMessage = PostMessage.from(messageText);
+        assertThat(postMessage.getParameters())
+                .isEqualTo(expectedParameters);
+    }
+
+    static Stream<Arguments> getParameters() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        new HashMap<String, String>() {{
+                            put("userId", "javajigi");
+                            put("password", "password");
+                            put("name", "박재성");
+                            put("email", "javajigi@slipp.net");
+                        }}
                 )
         );
     }

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -12,13 +12,13 @@ class PostMessageTest {
 
     @ParameterizedTest
     @MethodSource
-    void getRequestHeader(String messageText, RequestHeader expectedRequestHeader) {
+    void getHeader(String messageText, RequestHeader expectedRequestHeader) {
         PostMessage postMessage = PostMessage.from(messageText);
 
         assertThat(postMessage.getHeader()).isEqualTo(expectedRequestHeader);
     }
 
-    static Stream<Arguments> getRequestHeader() {
+    static Stream<Arguments> getHeader() {
         return Stream.of(
                 Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -5,20 +5,25 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class RequestHeaderTest {
+
     @ParameterizedTest
     @MethodSource
-    void from(String headerText, RequestHeader expectedHeader) {
-        assertThat(RequestHeader.from(headerText))
-                .isEqualTo(expectedHeader);
+    void getAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(Header.of(headerText, "request").getAttributes())
+                .isEqualTo(expectedAttributes);
     }
 
     @SuppressWarnings("unused")
-    static Stream<Arguments> from() {
+    static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
@@ -37,13 +42,59 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator(),
-                        RequestHeader.builder()
-                                .protocolVersion("HTTP/1.1")
-                                .method("GET")
-                                .path("/")
-                                .cookie("Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443")
-                                .host("localhost:8080")
-                                .build()
+                        new LinkedHashMap() {{
+                            put("Host", "localhost:8080");
+                            put("Connection", "keep-alive");
+                            put("Cache-Control", "max-age=0");
+                            put("sec-ch-ua", "\"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"");
+                            put("sec-ch-ua-mobile", "?0");
+                            put("Upgrade-Insecure-Requests", "1");
+                            put("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36");
+                            put("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9");
+                            put("Sec-Fetch-Site", "none");
+                            put("Sec-Fetch-Mode", "navigate");
+                            put("Sec-Fetch-User", "?1");
+                            put("Sec-Fetch-Dest", "document");
+                            put("Accept-Encoding", "gzip, deflate, br");
+                            put("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7");
+                            put("Cookie", "Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443");
+                        }}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(Header.of(headerText, "request").getStatusLineAttributes())
+                .isEqualTo(expectedAttributes);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> getStatusLineAttributes() {
+        return Stream.of(
+                Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        new HashMap() {{
+                            put("method", "GET");
+                            put("path", "/");
+                            put("protocolVersion", "HTTP/1.1");
+                        }}
                 )
         );
     }
@@ -51,8 +102,13 @@ class RequestHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        assertThat(RequestHeader.from(headerText).toByte())
-                .isEqualTo(expectedHeaderByte);
+        byte[] headerByte = Header.of(headerText, "request").toByte();
+
+        assertAll(
+                () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
+                () -> assertThat(new String(headerByte)).isEqualTo(new String(expectedHeaderByte))
+        );
+
     }
 
     @SuppressWarnings("unused")
@@ -78,6 +134,19 @@ class RequestHeaderTest {
                                 System.lineSeparator(),
                         ("GET / HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
                 )

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -18,50 +18,8 @@ class RequestHeaderTest {
     @ParameterizedTest
     @MethodSource
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(Header.of(headerText, "request").getAttributes())
+        assertThat(Header.requestHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
-    }
-
-    @ParameterizedTest
-    @MethodSource
-    void getMethod(String headerText, String expectedMethod) {
-        assertThat(((RequestHeader) Header.of(headerText, "request")).getMethod())
-                .isEqualTo(expectedMethod);
-    }
-
-    static Stream<Arguments> getMethod() {
-        return Stream.of(
-                Arguments.of(
-                        "GET / HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: none" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
-                                System.lineSeparator(),
-                        "GET"
-                ), Arguments.of(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 59" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
-                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                        "POST"
-                )
-        );
     }
 
     @SuppressWarnings("unused")
@@ -107,8 +65,50 @@ class RequestHeaderTest {
 
     @ParameterizedTest
     @MethodSource
+    void getMethod(String headerText, String expectedMethod) {
+        assertThat(Header.requestHeaderFrom(headerText).getMethod())
+                .isEqualTo(expectedMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of(
+                        "GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        "GET"
+                ), Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        "POST"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(Header.of(headerText, "request").getStatusLineAttributes())
+        assertThat(Header.requestHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
@@ -144,7 +144,7 @@ class RequestHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.of(headerText, "request").toByte();
+        byte[] headerByte = Header.requestHeaderFrom(headerText).toByte();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -13,16 +13,16 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+
 class RequestHeaderTest {
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getAttributes")
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.requestHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
@@ -42,7 +42,7 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator(),
-                        new LinkedHashMap() {{
+                        new LinkedHashMap<String, String>() {{
                             put("Host", "localhost:8080");
                             put("Connection", "keep-alive");
                             put("Cache-Control", "max-age=0");
@@ -64,7 +64,7 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getMethod")
     void getMethod(String headerText, String expectedMethod) {
         assertThat(Header.requestHeaderFrom(headerText).getMethod())
                 .isEqualTo(expectedMethod);
@@ -106,13 +106,12 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getStatusLineAttributes")
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.requestHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getStatusLineAttributes() {
         return Stream.of(
                 Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
@@ -132,7 +131,7 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator(),
-                        new HashMap() {{
+                        new HashMap<String, String>() {{
                             put("method", "GET");
                             put("path", "/");
                             put("protocolVersion", "HTTP/1.1");
@@ -142,7 +141,7 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("toByte")
     void toByte(String headerText, byte[] expectedHeaderByte) {
         byte[] headerByte = Header.requestHeaderFrom(headerText).toByte();
 
@@ -153,7 +152,6 @@ class RequestHeaderTest {
 
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> toByte() {
         return Stream.of(
                 Arguments.of(

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +44,42 @@ class RequestHeaderTest {
                                 .cookie("Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443")
                                 .host("localhost:8080")
                                 .build()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void toByte(String headerText, byte[] expectedHeaderByte) {
+        assertThat(RequestHeader.from(headerText).toByte())
+                .isEqualTo(expectedHeaderByte);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> toByte() {
+        return Stream.of(
+                Arguments.of(
+                        "GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        ("GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
                 )
         );
     }

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -22,6 +22,48 @@ class RequestHeaderTest {
                 .isEqualTo(expectedAttributes);
     }
 
+    @ParameterizedTest
+    @MethodSource
+    void getMethod(String headerText, String expectedMethod) {
+        assertThat(((RequestHeader) Header.of(headerText, "request")).getMethod())
+                .isEqualTo(expectedMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of(
+                        "GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        "GET"
+                ), Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        "POST"
+                )
+        );
+    }
+
     @SuppressWarnings("unused")
     static Stream<Arguments> getAttributes() {
         return Stream.of(

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -1,0 +1,49 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequestHeaderTest {
+    @ParameterizedTest
+    @MethodSource
+    void from(String headerText, RequestHeader expectedHeader) {
+        assertThat(RequestHeader.from(headerText))
+                .isEqualTo(expectedHeader);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        RequestHeader.builder()
+                                .protocolVersion("HTTP/1.1")
+                                .method("GET")
+                                .path("/")
+                                .cookie("Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443")
+                                .host("localhost:8080")
+                                .build()
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -141,9 +141,9 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("toByte")
-    void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.requestHeaderFrom(headerText).toByte();
+    @MethodSource("getBytes")
+    void getBytes(String headerText, byte[] expectedHeaderByte) {
+        byte[] headerByte = Header.requestHeaderFrom(headerText).getBytes();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
@@ -152,7 +152,7 @@ class RequestHeaderTest {
 
     }
 
-    static Stream<Arguments> toByte() {
+    static Stream<Arguments> getBytes() {
         return Stream.of(
                 Arguments.of(
                         "GET / HTTP/1.1" + System.lineSeparator() +

--- a/src/test/java/webserver/RequestMessageTest.java
+++ b/src/test/java/webserver/RequestMessageTest.java
@@ -1,0 +1,54 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class RequestMessageTest {
+    @ParameterizedTest
+    @MethodSource("fromGetMessage")
+    void fromGetMessage(String messageText) {
+        assertThat(RequestMessage.from(messageText))
+                .isEqualTo(GetMessage.from(messageText));
+    }
+
+    static Stream<Arguments> fromGetMessage() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("fromPostMessage")
+    void fromPostMessage(String messageText) {
+        assertThat(RequestMessage.from(messageText))
+                .isEqualTo(PostMessage.from(messageText));
+    }
+
+    static Stream<Arguments> fromPostMessage() {
+        return Stream.of(
+                Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net"
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/RequestTest.java
+++ b/src/test/java/webserver/RequestTest.java
@@ -1,0 +1,46 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class RequestTest {
+
+    @ParameterizedTest
+    @MethodSource("from")
+    void from(String inputMessage) {
+        InputStream inputStream = new ByteArrayInputStream(inputMessage.getBytes());
+        Request request = Request.from(inputStream);
+
+        assertThat(request.getRequestMessage()).isEqualTo(RequestMessage.from(inputMessage));
+    }
+
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator()
+                ), Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net"
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -1,0 +1,37 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResponseHeaderTest {
+    @ParameterizedTest
+    @MethodSource
+    void from(String headerText, ResponseHeader expectedHeader) {
+        assertThat(ResponseHeader.from(headerText))
+                .isEqualTo(expectedHeader);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+                        ResponseHeader.builder()
+                                .protocolVersion("HTTP/1.1")
+                                .statusCode("200")
+                                .statusText("OK")
+                                .contentType("text/html;charset=utf-8")
+                                .contentLength("Hello World".getBytes().length)
+                                .build()
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -15,13 +15,12 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ResponseHeaderTest {
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getAttributes")
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.responseHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of(
@@ -29,7 +28,7 @@ class ResponseHeaderTest {
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-                        new LinkedHashMap() {{
+                        new LinkedHashMap<String, String>() {{
                             put("Content-Type", "text/html;charset=utf-8");
                             put("Content-Length", String.valueOf("Hello World".getBytes().length));
                         }}
@@ -38,13 +37,12 @@ class ResponseHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getStatusLineAttributes")
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.responseHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getStatusLineAttributes() {
         return Stream.of(
                 Arguments.of(
@@ -62,7 +60,7 @@ class ResponseHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("toByte")
     void toByte(String headerText, byte[] expectedHeaderByte) {
         byte[] headerByte = Header.responseHeaderFrom(headerText).toByte();
 
@@ -72,7 +70,6 @@ class ResponseHeaderTest {
         );
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> toByte() {
         return Stream.of(
                 Arguments.of(

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,29 @@ class ResponseHeaderTest {
                                 .contentType("text/html;charset=utf-8")
                                 .contentLength("Hello World".getBytes().length)
                                 .build()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void toByte(String headerText, byte[] expectedHeaderByte) {
+        assertThat(ResponseHeader.from(headerText).toByte())
+                .isEqualTo(expectedHeaderByte);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> toByte() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+                        ("HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
                 )
         );
     }

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -5,33 +5,58 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
-    void from(String headerText, ResponseHeader expectedHeader) {
-        assertThat(ResponseHeader.from(headerText))
-                .isEqualTo(expectedHeader);
+    void getAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(ResponseHeader.of(headerText, "response").getAttributes())
+                .isEqualTo(expectedAttributes);
     }
 
     @SuppressWarnings("unused")
-    static Stream<Arguments> from() {
+    static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-                        ResponseHeader.builder()
-                                .protocolVersion("HTTP/1.1")
-                                .statusCode("200")
-                                .statusText("OK")
-                                .contentType("text/html;charset=utf-8")
-                                .contentLength("Hello World".getBytes().length)
-                                .build()
+                        new LinkedHashMap() {{
+                            put("Content-Type", "text/html;charset=utf-8");
+                            put("Content-Length", String.valueOf("Hello World".getBytes().length));
+                        }}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(Header.of(headerText, "response").getStatusLineAttributes())
+                .isEqualTo(expectedAttributes);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> getStatusLineAttributes() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+                        new HashMap() {{
+                            put("protocolVersion", "HTTP/1.1");
+                            put("statusText", "OK");
+                            put("statusCode", "200");
+                        }}
                 )
         );
     }
@@ -39,19 +64,23 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        assertThat(ResponseHeader.from(headerText).toByte())
-                .isEqualTo(expectedHeaderByte);
+        byte[] headerByte = Header.of(headerText, "response").toByte();
+
+        assertAll(
+                () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
+                () -> assertThat(new String(headerByte)).isEqualTo(new String(expectedHeaderByte))
+        );
     }
 
     @SuppressWarnings("unused")
     static Stream<Arguments> toByte() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-                        ("HTTP/1.1 200 OK " + System.lineSeparator() +
+                        ("HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator()).getBytes(StandardCharsets.UTF_8)

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -17,7 +17,7 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(ResponseHeader.of(headerText, "response").getAttributes())
+        assertThat(Header.responseHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
@@ -40,7 +40,7 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(Header.of(headerText, "response").getStatusLineAttributes())
+        assertThat(Header.responseHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
@@ -64,7 +64,7 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.of(headerText, "response").toByte();
+        byte[] headerByte = Header.responseHeaderFrom(headerText).toByte();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -60,9 +60,9 @@ class ResponseHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("toByte")
-    void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.responseHeaderFrom(headerText).toByte();
+    @MethodSource("getBytes")
+    void getBytes(String headerText, byte[] expectedHeaderByte) {
+        byte[] headerByte = Header.responseHeaderFrom(headerText).getBytes();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
@@ -70,7 +70,7 @@ class ResponseHeaderTest {
         );
     }
 
-    static Stream<Arguments> toByte() {
+    static Stream<Arguments> getBytes() {
         return Stream.of(
                 Arguments.of(
                         "HTTP/1.1 200 OK" + System.lineSeparator() +

--- a/src/test/java/webserver/ResponseMessageTest.java
+++ b/src/test/java/webserver/ResponseMessageTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class ResponseMessageTest {
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getHeader")
     void getHeader(String messageText, Header expectedRequestHeader) {
         ResponseMessage responseMessage = ResponseMessage.from(messageText);
 
@@ -33,7 +33,7 @@ class ResponseMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getBody")
     void getBody(String messageText, Body expectedBody) {
         ResponseMessage responseMessage = ResponseMessage.from(messageText);
 

--- a/src/test/java/webserver/ResponseMessageTest.java
+++ b/src/test/java/webserver/ResponseMessageTest.java
@@ -25,9 +25,9 @@ class ResponseMessageTest {
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator() +
                                 "Hello World",
-                        Header.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                        Header.responseHeaderFrom("HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator(), "response")
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator())
                 )
         );
     }

--- a/src/test/java/webserver/ResponseMessageTest.java
+++ b/src/test/java/webserver/ResponseMessageTest.java
@@ -1,0 +1,55 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ResponseMessageTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void getHeader(String messageText, Header expectedRequestHeader) {
+        ResponseMessage responseMessage = ResponseMessage.from(messageText);
+
+        assertThat(responseMessage.getHeader()).isEqualTo(expectedRequestHeader);
+    }
+
+    static Stream<Arguments> getHeader() {
+        return Stream.of(
+                Arguments.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator() +
+                                "Hello World",
+                        Header.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator(), "response")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getBody(String messageText, Body expectedBody) {
+        ResponseMessage responseMessage = ResponseMessage.from(messageText);
+
+        assertThat(responseMessage.getBody()).isEqualTo(expectedBody);
+    }
+
+    static Stream<Arguments> getBody() {
+        return Stream.of(
+                Arguments.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator() +
+                                "Hello World",
+                        Body.from("Hello World")
+                )
+        );
+    }
+
+}

--- a/src/test/java/webserver/ResponseTest.java
+++ b/src/test/java/webserver/ResponseTest.java
@@ -1,0 +1,34 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ResponseTest {
+    @ParameterizedTest
+    @MethodSource("write")
+    void write(String message) {
+        Response response = Response.from(message);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        response.write(outputStream);
+        ResponseMessage responseMessage = ResponseMessage.from(outputStream.toString());
+        assertThat(response).isEqualTo(new Response(responseMessage));
+    }
+
+    static Stream<Arguments> write() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator() +
+                                "Hello World"
+                )
+        );
+    }
+}


### PR DESCRIPTION
HTTP의 구조와 같은 기초 부분에서 이해도가 부족한 것 같아 학습을 하면서,

요구사항 처리 이전에 요구사항을 토대로 설계를 먼저해보고, 그에 따라 저희가 생각한대로 구조를 잡는 작업을 먼저 해봤습니다.

이를 위해 페어프로그래밍을 통해 요구사항을 분석해보고 그걸 토대로 클래스 다이어그램을 만들었는데,

구조를 먼저 생각하다보니 요구사항과 함께 처리하게 되면 풀 리퀘스트 단위가 너무 커질 것 같아서, 본격적인 요구사항 반영에 앞서 리뷰 요청을 한 번 드리기로 결정했습니다.

그래서 현재는 요구사항 보다는 설계한 클래스 다이어그램에 맞춰서 개발이 진행되었습니다. 구체적인 미션 요구사항은 다음 풀리퀘스트부터 제대로 반영될 것 같습니다.

한 번에 요구사항 만족을 모두 시키는게 벅찰 것 같아서 일단 이런식으로 해봤는데, 풀리퀘스트를 보내려고 해보니 요구사항을 제대로 충족한게 하나도 없는 것 같아 이런 식의 개발 방향이 맞는지 의문도 생겼습니다.

## 개발 과정

[테스트 수정](https://github.com/sanhee/java-was/milestone/1?closed=1)
[클래스다이어그램 기반 코드 작성](https://github.com/sanhee/java-was/milestone/2?closed=1)

구현 세부사항은 아래와 같습니다.

### 테스트 수정

- 기본 설정이 JUnit4로 되어있어서, JUnit5로 변경해줬습니다.
- 변경하면서 ParameterizedTest를 적용해봤습니다.

### 클래스다이어그램을 토대로 구현

[요구사항 정리](https://www.notion.so/sanhee/f28738b66c5947cfa418ddd9961aa267)

[클래스다이어그램(초기 설계)](https://app.genmymodel.com/api/projects/_8bpTsIxOEeu9--9sQCgRag/diagrams/_8bpTs4xOEeu9--9sQCgRag/svg)

처음 설계는 위와 같았습니다. 요구사항에 따라 필요한 객체들을 나눠보고 해당 객체가 어떤 작업을 해야할지 정해봤습니다. 그리고 거기에 맞춰서 구조를 잡아봤는데 결과는 다음과 같았습니다.

[클래스다이어그램(구현 결과)](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/a5f84ea9-9d32-4ea1-b071-f0ef69dec248/Package_webserver.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAT73L2G45O3KS52Y5%2F20210331%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210331T015742Z&X-Amz-Expires=86400&X-Amz-Signature=f5aa883083b048e7f15b55f70a49eb458a39607935b846ab067f54d514ed566e&X-Amz-SignedHeaders=host)

#### Header

- 헤더의 항목들을 일일이 필드로 저장하기에는 한계가 있다고 판단되어, attribute는 `Map`에 저장했습니다.
    - 실제로 request로 들어오는 헤더는 항목이 아주 많은데, 기존에는 그 중에서 몇 가지만 선별하도록 구현을 했습니다. 사용하는 헤더가 적으면 크게 문제가 없지만, 필요한 항목이 많아질 수록 코드가 복잡해졌습니다.
    - 이를 해결하기위해 [`a8e355e`](https://github.com/sanhee/java-was/commit/a8e355e62e1f464c3a4808d500e2958adc54c4ba) 에서 빌더를 추가하는 등의 수정을 했었는데, `Map`을 이용하면 이러한 부분이 자연스럽게 제거돼서 훨씬 깔끔하게 구현할 수 있었습니다.
    - 뿐만 아니라, attribute들이 구체적인 필드가 아닌, `Map`으로 추상화되어 있기 때문에 쉽게 추상화 할 수 있었습니다.
- `Map<String, String>` 이외에 `List<Pair>`를 고려해볼 수도 있었는데, 그렇게 되면 별개의 클래스로 추출해야 할 것 같아 일단은 `Map`을 사용하기로 했습니다.

#### RequestHeader와 ResponseHeader

- status line이 서로 다르기 때문에 구분했습니다. 이를 위해 `Header`에 `attributes`와 별개로  `statusLineAttributes`를 추가했습니다.
    - 그리고 출력할 때는 `getBytes()`를 이용하는데 status line을 가져오는 추상 메서드 이외에는 중복되는 부분이라서 부모 클래스인 `Header`에 정의해줬습니다.

#### Message

- 헤더가 다르기 때문에 리퀘스트와 리스폰스 메시지로 나눴습니다.
- `HttpMessage`로 리퀘스트와 리스폰스를 합치는 방향도 생각해봤는데, 과도한 추상화인 것 같아 그렇게 하지 않았습니다. Message객체들을 사용할 상위 객체인 `Request`와 `Response`에 필요한 Message의 역할이 서로 다르기 때문입니다.

![image](https://user-images.githubusercontent.com/73760074/112925067-381e8b80-914c-11eb-93e8-f907be8e7246.png)

> 원래 설계의 형태는 위와 같았습니다.

#### RequestMessage

- 리퀘스트 메시지는 `Body`의 유무로 나눴습니다.
- `Request Message`를 앞으로 사용하는 클래스에서 Get / Post를 유연하게 사용할 수 있도록 인터페이스를 정의하였습니다.
- `getParameters() `은 Get은 path뒤에, Post는 body에 데이터가 포함되기 때문에 형식에 맞게 파싱해서 Map으로 리턴해줍니다.
    - 파싱 된 결과를 필드에 저장하는 방식도 고려해봤는데, 지금은 성능적으로 문제가 없을 것 같아 요청이 올 때마다 데이터를 파싱해서 리턴해주도록 구현했습니다.

#### GetMessage

- 헤더에서 쿼리 스트링을 파싱하는 역할
- Status Line에서 path 부분을 가져와서, 쿼리 스트링과 분리를 해주는데 `URI` 클래스에서 `getQuery()` 을 제공해주고, 내부적으로 `decodedQuery` 을 제공해줍니다.

#### PostMessage

- 바디를 파싱하는 기능

- `Body`의 경우는 주소가 아니기 때문에 `URI`나 `URL`객체를 바로 사용하기는 애매한 것 같아서, `URLDecoder.decode` 를 이용해 퍼센트 인코딩을 디코딩하였습니다.

    > 예를 들어, `URI`객체에 있는 주소에서 쿼리를 분리해주는 기능을 사용하려면 객체 생성 시 `?name=...`과 같이 작성해야 한다.

#### ResponseMessage

- `PostMessage`와 구조가 동일하지만, header가 다르고 추후 내부적으로 동작이 달라질 것 같아서 추상화를 시키지 않았습니다.
- header와 body를 나눠주는 기능은 나중에 util로 분리를 고려해볼 수 있을 것 같다고 생각했습니다.

#### Request

- `RequestHandler`에서 직접 사용할 객체.
- connection에서 가져오는 `InputStream`을 `RequestMessage`로 바꿔줍니다.

#### Response

- 리스폰스 메시지를 받아서, `OutputStream` 으로 전송.
- 테스트에서 flush결과를 볼 수 없어 `ByteArrayOutputStream`을 사용했습니다.
- 비교를 위해 `ResponseMessage`에 equals 추가함.

감사합니다.